### PR TITLE
feat: 简单重构增加局部刷新和文本显示功能

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ using (var oled = new SSD1306_128_64(1)) {
             Style = SKPaintStyle.Fill,
         };
 
-        SKFont font = new SKFont(SKTypeface.FromFile("/home/sangsq/i2c_led/SourceHanSansCN-Normal.ttf"),13);
+        SKFont font = new SKFont(SKTypeface.FromFile("/home/fonts/SourceHanSansCN-Normal.ttf"),13);
 
         canvas.DrawText("公众号：sangxiao99 ", 0, 13, font, paint);
         font.Size = 30;
@@ -81,6 +81,52 @@ using (var oled = new SSD1306_128_64(1)) {
 }
 ```
 
+
+## Display Text
+
+```csharp
+using Sang.IoT.SSD1306;
+using SkiaSharp;
+
+using (var oled = new SSD1306_128_64(1)) {
+
+    oled.Begin();
+    oled.Clear();
+    oled.DrawText("大河向东流", 0, 16, "/home/fonts/SourceHanSansCN-Normal.ttf", 40);
+    oled.Display();
+}
+```
+
+## Partial refresh
+
+```csharp
+using Sang.IoT.SSD1306;
+using SkiaSharp;
+
+using (var oled = new SSD1306_128_64(1)) {
+
+    oled.Begin();
+    oled.Clear();
+    oled.DrawText("大河向东流", 0, 16, "/home/fonts/SourceHanSansCN-Normal.ttf", 40);
+    oled.Display();
+    
+    using (var bitmap = new SKBitmap(64, 54, true))
+    {
+        SKCanvas canvas = new SKCanvas(bitmap);
+        using var paint = new SKPaint
+        {
+            Color = new SKColor(255, 255, 255),
+            StrokeWidth = 1, //画笔宽度
+            Style = SKPaintStyle.Fill,
+        };
+        SKFont font = new SKFont(SKTypeface.FromFile("/home/fonts/SourceHanSansCN-Normal.ttf"), 30);
+        canvas.DrawText("桑榆肖物 ", 0, 40, font, paint);
+        oled.Image(bitmap.Encode(SKEncodedImageFormat.Png, 100).ToArray(), 0, 10, 64, 54);
+    }
+    
+    oled.Display();
+}
+```
 
 ## Clear
 

--- a/README.md
+++ b/README.md
@@ -66,13 +66,14 @@ using (var oled = new SSD1306_128_64(1)) {
         SKPaint paint = new SKPaint() { 
             Color = new SKColor(255, 255, 255),
             StrokeWidth = 1, //画笔宽度
-            Typeface = SKTypeface.FromFile("/home/sangsq/i2c_led/SourceHanSansCN-Normal.ttf"),
-            TextSize = 13,  //字体大小
             Style = SKPaintStyle.Fill,
         };
-        canvas.DrawText("公众号：sangxiao99 ", 0, 13, paint);
-        paint.TextSize = 30;
-        canvas.DrawText("桑榆肖物 ", 0, 50, paint);
+
+        SKFont font = new SKFont(SKTypeface.FromFile("/home/sangsq/i2c_led/SourceHanSansCN-Normal.ttf"),13);
+
+        canvas.DrawText("公众号：sangxiao99 ", 0, 13, font, paint);
+        font.Size = 30;
+        canvas.DrawText("桑榆肖物 ", 0, 50, font, paint);
         oled.Image(bitmap.Encode(SKEncodedImageFormat.Png, 100).ToArray());
     }
 

--- a/Sang.IoT.SSD1306.Test/Program.cs
+++ b/Sang.IoT.SSD1306.Test/Program.cs
@@ -5,6 +5,7 @@ internal class Program
 {
     private static void Main(string[] args)
     {
+        ImageTest();
         BaseTest();
     }
 
@@ -36,6 +37,27 @@ internal class Program
             }
 
             oled.Display();
+        }
+    }
+
+    private static void ImageTest()
+    {
+        using (var bitmap = new SKBitmap(128, 64, true))
+        {
+            SKCanvas canvas = new SKCanvas(bitmap);
+            SKPaint paint = new SKPaint()
+            {
+                Color = new SKColor(255, 255, 255),
+                StrokeWidth = 1, //画笔宽度
+                Style = SKPaintStyle.Fill,
+            };
+            SKFont font = new SKFont(SKTypeface.Default, 13);
+
+            canvas.DrawText("Sang.IoT.SSD1306 ", 0, 13, font, paint);
+            font.Size = 30;
+            canvas.DrawText("桑榆肖物 ", 0, 50, font, paint);
+            using (FileStream fs = new FileStream("tmp.png", FileMode.Create))
+                bitmap.Encode(SKEncodedImageFormat.Png, 100).SaveTo(fs);
         }
     }
 }

--- a/Sang.IoT.SSD1306.Test/Program.cs
+++ b/Sang.IoT.SSD1306.Test/Program.cs
@@ -1,0 +1,41 @@
+﻿using Sang.IoT.SSD1306;
+using SkiaSharp;
+
+internal class Program
+{
+    private static void Main(string[] args)
+    {
+        BaseTest();
+    }
+
+    private static void BaseTest()
+    {
+        using (var oled = new SSD1306_128_64(1))
+        {
+
+            oled.Begin();
+            oled.Clear();
+
+            using (var bitmap = new SKBitmap(128, 64, true))
+            {
+                SKCanvas canvas = new SKCanvas(bitmap);
+                SKPaint paint = new SKPaint()
+                {
+                    Color = new SKColor(255, 255, 255),
+                    StrokeWidth = 1, //画笔宽度
+                    Style = SKPaintStyle.Fill,
+                };
+                SKFont font = new SKFont(SKTypeface.Default, 13);
+
+                canvas.DrawText("Sang.IoT.SSD1306 ", 0, 13, font, paint);
+                font.Size = 30;
+                canvas.DrawText("桑榆肖物 ", 0, 50, font, paint);
+                using (FileStream fs = new FileStream("tmp.png", FileMode.Create))
+                    bitmap.Encode(SKEncodedImageFormat.Png, 100).SaveTo(fs);
+                oled.Image(bitmap.Encode(SKEncodedImageFormat.Png, 100).ToArray());
+            }
+
+            oled.Display();
+        }
+    }
+}

--- a/Sang.IoT.SSD1306.Test/Sang.IoT.SSD1306.Test.csproj
+++ b/Sang.IoT.SSD1306.Test/Sang.IoT.SSD1306.Test.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Sang.IoT.SSD1306\Sang.IoT.SSD1306.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Sang.IoT.SSD1306.sln
+++ b/Sang.IoT.SSD1306.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.2.32602.215
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sang.IoT.SSD1306", "Sang.IoT.SSD1306\Sang.IoT.SSD1306.csproj", "{0942368E-3487-489B-BECC-D85770372879}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sang.IoT.SSD1306.Test", "Sang.IoT.SSD1306.Test\Sang.IoT.SSD1306.Test.csproj", "{ADEC9635-C239-49E4-BAD6-145FA5C87F10}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{0942368E-3487-489B-BECC-D85770372879}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0942368E-3487-489B-BECC-D85770372879}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0942368E-3487-489B-BECC-D85770372879}.Release|Any CPU.Build.0 = Release|Any CPU
+		{ADEC9635-C239-49E4-BAD6-145FA5C87F10}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ADEC9635-C239-49E4-BAD6-145FA5C87F10}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ADEC9635-C239-49E4-BAD6-145FA5C87F10}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ADEC9635-C239-49E4-BAD6-145FA5C87F10}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Sang.IoT.SSD1306/SSD1306_128_64.cs
+++ b/Sang.IoT.SSD1306/SSD1306_128_64.cs
@@ -1,6 +1,4 @@
-﻿using SkiaSharp;
-
-namespace Sang.IoT.SSD1306
+﻿namespace Sang.IoT.SSD1306
 {
     public class SSD1306_128_64 : SSD1306_Base
     {
@@ -49,53 +47,6 @@ namespace Sang.IoT.SSD1306
             Command(0x40);
             Command(SSD1306_DISPLAYALLON_RESUME);   // 0xA4
             Command(SSD1306_NORMALDISPLAY);         // 0xA6
-        }
-
-        /// <summary>
-        /// 设置图片数据 128*64
-        /// </summary>
-        /// <param name="filepath">图片路径</param>
-        public void Image(string filepath) {
-            Image(SKBitmap.Decode(filepath));
-        }
-
-        /// <summary>
-        /// 设置图片数据 128*64
-        /// </summary>
-        /// <param name="imageData">图片数据</param>
-        public void Image(byte[] imageData)
-        {
-            Image(SKBitmap.Decode(imageData));
-        }
-
-        private void Image(SKBitmap bitmap)
-        {
-            if (bitmap.Width != 128 || bitmap.Height != 64) return;
-
-            byte[] Data = new byte[this.width * this.pages];
-            int index = 0;
-            for (int page = 0; page < this.pages; page++)
-            {
-                for (int x = 0; x < this.width; x++)
-                {
-                    int bits = 0;
-                    for (int bit = 0; bit < 8; bit++)
-                    {
-                        bits = bits << 1;
-                        if (bitmap.GetPixel(x, page * 8 + 7 - bit).ToString() == "#ff000000")
-                        {
-                            bits = bits | 0;
-                        }
-                        else
-                        {
-                            bits = bits | 1;
-                        }
-                    }
-                    Data[index] = (byte)bits;
-                    index++;
-                }
-            }
-            this.SetBuffer(Data);
         }
     }
 }

--- a/Sang.IoT.SSD1306/SSD1306_Base.cs
+++ b/Sang.IoT.SSD1306/SSD1306_Base.cs
@@ -92,7 +92,6 @@ namespace Sang.IoT.SSD1306
             this.height = height;
             this.pages = (int)Math.Floor(height / 8.0);
             this._buffer = new byte[width * this.pages];
-
             this._bus = I2cBus.Create(i2c_bus);
             this._i2c = _bus.CreateDevice(i2c_address);
 

--- a/Sang.IoT.SSD1306/SSD1306_Base.cs
+++ b/Sang.IoT.SSD1306/SSD1306_Base.cs
@@ -2,7 +2,7 @@
 
 namespace Sang.IoT.SSD1306
 {
-    public class SSD1306_Base : IDisposable
+    public partial class SSD1306_Base : IDisposable
     {
         #region 常量
         public const byte SSD1306_I2C_ADDRESS = 0x3C;    // 011110+SA0+RW - 0x3C or 0x3D
@@ -151,6 +151,19 @@ namespace Sang.IoT.SSD1306
         }
 
         /// <summary>
+        /// 设置显示器buffer的特定区域
+        /// </summary>
+        public void SetBuffer(byte[] c, int x, int y, int regionWidth, int regionHeight) {
+            int pages = (regionHeight + 7) / 8;
+            int bufferWidth = this.width;
+            for (int page = 0; page < pages; page++) {
+                int bufferIndex = (y / 8 + page) * bufferWidth + x;
+                int sourceIndex = page * regionWidth;
+                Array.Copy(c, sourceIndex, _buffer, bufferIndex, regionWidth);
+            }
+        }
+
+        /// <summary>
         /// 将buffer数据写入到显示器
         /// </summary>
         public void Display()
@@ -173,6 +186,7 @@ namespace Sang.IoT.SSD1306
         public void Clear()
         {
             this._buffer = new byte[width * this.pages];
+            Display();
         }
 
 

--- a/Sang.IoT.SSD1306/SSD1306_Base.cs
+++ b/Sang.IoT.SSD1306/SSD1306_Base.cs
@@ -145,7 +145,8 @@ namespace Sang.IoT.SSD1306
         /// <summary>
         /// 设置显示器buffer
         /// </summary>
-        public void SetBuffer(byte[] c) {
+        public void SetBuffer(byte[] c)
+        {
             if (c.Length != _buffer.Length) return;
             _buffer = c;
         }
@@ -153,10 +154,12 @@ namespace Sang.IoT.SSD1306
         /// <summary>
         /// 设置显示器buffer的特定区域
         /// </summary>
-        public void SetBuffer(byte[] c, int x, int y, int regionWidth, int regionHeight) {
+        public void SetBuffer(byte[] c, int x, int y, int regionWidth, int regionHeight)
+        {
             int pages = (regionHeight + 7) / 8;
             int bufferWidth = this.width;
-            for (int page = 0; page < pages; page++) {
+            for (int page = 0; page < pages; page++)
+            {
                 int bufferIndex = (y / 8 + page) * bufferWidth + x;
                 int sourceIndex = page * regionWidth;
                 Array.Copy(c, sourceIndex, _buffer, bufferIndex, regionWidth);

--- a/Sang.IoT.SSD1306/SSD1306_Display.cs
+++ b/Sang.IoT.SSD1306/SSD1306_Display.cs
@@ -1,0 +1,64 @@
+using SkiaSharp;
+
+namespace Sang.IoT.SSD1306
+{
+    public partial class SSD1306_Base
+    {
+        /// <summary>
+        /// 设置图片数据
+        /// </summary>
+        /// <param name="filePath">图片路径</param>
+        public void Image(string filePath)
+        {
+            Image(SKBitmap.Decode(filePath));
+        }
+
+        /// <summary>
+        /// 设置图片数据
+        /// </summary>
+        /// <param name="imageData">图片数据</param>
+        public void Image(byte[] imageData)
+        {
+            Image(SKBitmap.Decode(imageData));
+        }
+
+        /// <summary>
+        /// 设置图片数据
+        /// </summary>
+        /// <param name="bitmap">图片数据</param>
+        /// <param name="startX">起始X坐标</param>
+        /// <param name="startY">起始Y坐标</param>
+        /// <param name="regionWidth">区域宽度</param>
+        /// <param name="regionHeight">区域高度</param>
+        public void Image(SKBitmap bitmap, int startX = 0, int startY = 0, int regionWidth = 128, int regionHeight = 64)
+        {
+            if (bitmap.Width < startX + regionWidth || bitmap.Height < startY + regionHeight) return;
+
+            byte[] data = new byte[regionWidth * ((regionHeight + 7) / 8)];
+            int index = 0;
+            for (int page = 0; page < (regionHeight + 7) / 8; page++)
+            {
+                for (int i = 0; i < regionWidth; i++)
+                {
+                    data[index++] = GetByteForColumn(bitmap, i + startX, startY + page * 8);
+                }
+            }
+            this.SetBuffer(data, startX, startY, regionWidth, regionHeight);
+        }
+
+        private byte GetByteForColumn(SKBitmap bitmap, int x, int startY)
+        {
+            int bits = 0;
+            for (int bit = 0; bit < 8; bit++)
+            {
+                bits <<= 1;
+                int pixelY = startY + 7 - bit;
+                if (pixelY < bitmap.Height && bitmap.GetPixel(x, pixelY).Alpha == 255)
+                {
+                    bits |= 1;
+                }
+            }
+            return (byte)bits;
+        }
+    }
+}

--- a/Sang.IoT.SSD1306/SSD1306_Display.cs
+++ b/Sang.IoT.SSD1306/SSD1306_Display.cs
@@ -14,13 +14,14 @@ namespace Sang.IoT.SSD1306
         /// <param name="fontFile">字体文件</param>
         /// <param name="fontSize">字体大小，默认13</param>
         /// <param name="bgHeight">背景高度，默认字体大小+3</param>
-        /// <param name="bgWdith">背景宽度，默认剩余空间</param>
-        public void DrawText(string text, int x, int y, string fontFile, int fontSize = 13, int bgHeight = 0, int bgWdith = 0)
+        /// <param name="bgWidth">背景宽度，默认剩余空间</param>
+        /// <param name="drawOffset">绘制偏移量，默认0</param>
+        public void DrawText(string text, int x, int y, string fontFile, int fontSize = 13, int bgHeight = 0, int bgWidth = 0, int drawOffset = 0)
         {
-            bgWdith = bgWdith <= 0 ? this.width - x : bgWdith;
+            bgWidth = bgWidth <= 0 ? this.width - x : bgWidth;
             bgHeight = bgHeight <= 0 ? fontSize + 3 : bgHeight;
 
-            var regionWidth = Math.Min(bgWdith, this.width - x);
+            var regionWidth = Math.Min(bgWidth, this.width - x);
             var regionHeight = Math.Min(bgHeight, this.height - y);
 
             using (var bitmap = new SKBitmap(regionWidth, regionHeight, true))
@@ -33,7 +34,7 @@ namespace Sang.IoT.SSD1306
                     Style = SKPaintStyle.Fill,
                 };
                 SKFont font = new(SKTypeface.FromFile(fontFile), fontSize);
-                canvas.DrawText(text, 0, 0, font, paint);
+                canvas.DrawText(text, 0, fontSize + drawOffset, font, paint);
                 Image(bitmap.Encode(SKEncodedImageFormat.Png, 100).ToArray(), x, y, regionWidth, regionHeight);
             }
         }

--- a/Sang.IoT.SSD1306/SSD1306_Display.cs
+++ b/Sang.IoT.SSD1306/SSD1306_Display.cs
@@ -4,6 +4,41 @@ namespace Sang.IoT.SSD1306
 {
     public partial class SSD1306_Base
     {
+
+        /// <summary>
+        /// 绘制文本
+        /// </summary>
+        /// <param name="text">文本内容</param>
+        /// <param name="x">X坐标</param>
+        /// <param name="y">Y坐标</param>
+        /// <param name="fontFile">字体文件</param>
+        /// <param name="fontSize">字体大小，默认13</param>
+        /// <param name="bgHeight">背景高度，默认字体大小+3</param>
+        /// <param name="bgWdith">背景宽度，默认剩余空间</param>
+        public void DrawText(string text, int x, int y, string fontFile, int fontSize = 13, int bgHeight = 0, int bgWdith = 0)
+        {
+            bgWdith = bgWdith <= 0 ? this.width - x : bgWdith;
+            bgHeight = bgHeight <= 0 ? fontSize + 3 : bgHeight;
+
+            var regionWidth = Math.Min(bgWdith, this.width - x);
+            var regionHeight = Math.Min(bgHeight, this.height - y);
+
+            using (var bitmap = new SKBitmap(regionWidth, regionHeight, true))
+            {
+                SKCanvas canvas = new(bitmap);
+                SKPaint paint = new()
+                {
+                    Color = new SKColor(255, 255, 255),
+                    StrokeWidth = 1,
+                    Style = SKPaintStyle.Fill,
+                };
+                SKFont font = new(SKTypeface.FromFile(fontFile), fontSize);
+                canvas.DrawText(text, 0, 0, font, paint);
+                Image(bitmap.Encode(SKEncodedImageFormat.Png, 100).ToArray(), x, y, regionWidth, regionHeight);
+            }
+        }
+
+
         /// <summary>
         /// 设置图片数据
         /// </summary>

--- a/Sang.IoT.SSD1306/SSD1306_Display.cs
+++ b/Sang.IoT.SSD1306/SSD1306_Display.cs
@@ -34,28 +34,31 @@ namespace Sang.IoT.SSD1306
         {
             if (bitmap.Width < startX + regionWidth || bitmap.Height < startY + regionHeight) return;
 
-            byte[] data = new byte[regionWidth * ((regionHeight + 7) / 8)];
+            byte[] data = new byte[this.width * this.pages];
             int index = 0;
-            for (int page = 0; page < (regionHeight + 7) / 8; page++)
+            for (int page = 0; page < this.pages; page++)
             {
-                for (int i = 0; i < regionWidth; i++)
+                for (int i = 0; i < this.width; i++)
                 {
-                    data[index++] = GetByteForColumn(bitmap, i + startX, startY + page * 8);
+                    data[index++] = GetByteForColumn(bitmap, i , page);
                 }
             }
             this.SetBuffer(data, startX, startY, regionWidth, regionHeight);
         }
 
-        private byte GetByteForColumn(SKBitmap bitmap, int x, int startY)
+        private byte GetByteForColumn(SKBitmap bitmap, int x, int page)
         {
             int bits = 0;
             for (int bit = 0; bit < 8; bit++)
             {
                 bits <<= 1;
-                int pixelY = startY + 7 - bit;
-                if (pixelY < bitmap.Height && bitmap.GetPixel(x, pixelY).Alpha == 255)
+                if (bitmap.GetPixel(x, page * 8 + 7 - bit).ToString() == "#ff000000")
                 {
-                    bits |= 1;
+                    bits = bits | 0;
+                }
+                else
+                {
+                    bits = bits | 1;
                 }
             }
             return (byte)bits;

--- a/Sang.IoT.SSD1306/SSD1306_Display.cs
+++ b/Sang.IoT.SSD1306/SSD1306_Display.cs
@@ -8,18 +8,26 @@ namespace Sang.IoT.SSD1306
         /// 设置图片数据
         /// </summary>
         /// <param name="filePath">图片路径</param>
-        public void Image(string filePath)
+        /// <param name="startX">起始X坐标</param>
+        /// <param name="startY">起始Y坐标</param>
+        /// <param name="regionWidth">区域宽度</param>
+        /// <param name="regionHeight">区域高度</param>
+        public void Image(string filePath, int startX = 0, int startY = 0, int regionWidth = 128, int regionHeight = 64)
         {
-            Image(SKBitmap.Decode(filePath));
+            Image(SKBitmap.Decode(filePath), startX, startY, regionWidth, regionHeight);
         }
 
         /// <summary>
         /// 设置图片数据
         /// </summary>
         /// <param name="imageData">图片数据</param>
-        public void Image(byte[] imageData)
+        /// <param name="startX">起始X坐标</param>
+        /// <param name="startY">起始Y坐标</param>
+        /// <param name="regionWidth">区域宽度</param>
+        /// <param name="regionHeight">区域高度</param>
+        public void Image(byte[] imageData, int startX = 0, int startY = 0, int regionWidth = 128, int regionHeight = 64)
         {
-            Image(SKBitmap.Decode(imageData));
+            Image(SKBitmap.Decode(imageData), startX, startY, regionWidth, regionHeight);
         }
 
         /// <summary>
@@ -32,33 +40,51 @@ namespace Sang.IoT.SSD1306
         /// <param name="regionHeight">区域高度</param>
         public void Image(SKBitmap bitmap, int startX = 0, int startY = 0, int regionWidth = 128, int regionHeight = 64)
         {
-            if (bitmap.Width < startX + regionWidth || bitmap.Height < startY + regionHeight) return;
+            // 边界检查
+            if (startX < 0 || startY < 0 || startX >= this.width || startY >= this.height) return;
 
-            byte[] data = new byte[this.width * this.pages];
+            // 调整区域大小确保不超出显示范围
+            regionWidth = Math.Min(regionWidth, this.width - startX);
+            regionHeight = Math.Min(regionHeight, this.height - startY);
+
+            if (bitmap.Width < regionWidth || bitmap.Height < regionHeight) return;
+
+            // 计算需要更新的页数
+            int startPage = startY / 8;
+            int endPage = (startY + regionHeight + 7) / 8;
+            int pageCount = endPage - startPage;
+
+            byte[] data = new byte[regionWidth * pageCount];
             int index = 0;
-            for (int page = 0; page < this.pages; page++)
+
+            for (int page = 0; page < pageCount; page++)
             {
-                for (int i = 0; i < this.width; i++)
+                for (int x = 0; x < regionWidth; x++)
                 {
-                    data[index++] = GetByteForColumn(bitmap, i , page);
+                    data[index++] = GetByteForColumn(bitmap, x, page, startY % 8);
                 }
             }
+
             this.SetBuffer(data, startX, startY, regionWidth, regionHeight);
         }
 
-        private byte GetByteForColumn(SKBitmap bitmap, int x, int page)
+        private byte GetByteForColumn(SKBitmap bitmap, int x, int page, int yOffset)
         {
             int bits = 0;
             for (int bit = 0; bit < 8; bit++)
             {
                 bits <<= 1;
-                if (bitmap.GetPixel(x, page * 8 + 7 - bit).ToString() == "#ff000000")
+                int y = page * 8 + 7 - bit + yOffset;
+                if (y < bitmap.Height)
                 {
-                    bits = bits | 0;
-                }
-                else
-                {
-                    bits = bits | 1;
+                    if (bitmap.GetPixel(x, y).ToString() == "#ff000000")
+                    {
+                        bits = bits | 0;
+                    }
+                    else
+                    {
+                        bits = bits | 1;
+                    }
                 }
             }
             return (byte)bits;

--- a/Sang.IoT.SSD1306/Sang.IoT.SSD1306.csproj
+++ b/Sang.IoT.SSD1306/Sang.IoT.SSD1306.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>

--- a/Sang.IoT.SSD1306/Sang.IoT.SSD1306.csproj
+++ b/Sang.IoT.SSD1306/Sang.IoT.SSD1306.csproj
@@ -14,7 +14,7 @@
     <PackageProjectUrl>https://github.com/marin1993/Sang.IoT.SSD1306</PackageProjectUrl>
     <Description>.NET library to use SSD1306-based 128x64 pixel OLED displays with a IoT device.Passed the test on the Jetson nano device.
 .NET 类库，用于驱动 IOT 设备基于 SSD1306 分辨率 128*64 的 OLED 显示器，已在 Jetson Nano 设备上测试通过。</Description>
-    <Version>2.0.0</Version>
+    <Version>2.0.1</Version>
     <Authors>SangSQ(桑世强)</Authors>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>

--- a/Sang.IoT.SSD1306/Sang.IoT.SSD1306.csproj
+++ b/Sang.IoT.SSD1306/Sang.IoT.SSD1306.csproj
@@ -31,8 +31,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.0" />
-    <PackageReference Include="System.Device.Gpio" Version="2.1.0" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="3.116.1" />
+    <PackageReference Include="System.Device.Gpio" Version="3.2.0" />
   </ItemGroup>
 
 </Project>

--- a/Sang.IoT.SSD1306/Sang.IoT.SSD1306.csproj
+++ b/Sang.IoT.SSD1306/Sang.IoT.SSD1306.csproj
@@ -14,7 +14,7 @@
     <PackageProjectUrl>https://github.com/marin1993/Sang.IoT.SSD1306</PackageProjectUrl>
     <Description>.NET library to use SSD1306-based 128x64 pixel OLED displays with a IoT device.Passed the test on the Jetson nano device.
 .NET 类库，用于驱动 IOT 设备基于 SSD1306 分辨率 128*64 的 OLED 显示器，已在 Jetson Nano 设备上测试通过。</Description>
-    <Version>1.2.4</Version>
+    <Version>2.0.0</Version>
     <Authors>SangSQ(桑世强)</Authors>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
@@ -31,6 +31,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="SkiaSharp" Version="3.116.1" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="3.116.1" />
     <PackageReference Include="System.Device.Gpio" Version="3.2.0" />
   </ItemGroup>


### PR DESCRIPTION
This pull request includes several significant changes to the `Sang.IoT.SSD1306` project, including updates to the display functionality, project configuration, and documentation. The most important changes are summarized below:

### Display Functionality Enhancements:
* Added new methods for drawing text and images on the OLED display, including support for partial refresh and specifying regions (`Sang.IoT.SSD1306/SSD1306_Display.cs`).
* Removed redundant image handling methods from `SSD1306_128_64` and moved them to a new partial class (`Sang.IoT.SSD1306/SSD1306_128_64.cs`).

### Project Configuration Updates:
* Updated the project to target both .NET 8.0 and .NET 9.0 frameworks (`Sang.IoT.SSD1306/Sang.IoT.SSD1306.csproj`).
* Added a new test project `Sang.IoT.SSD1306.Test` and included it in the solution (`Sang.IoT.SSD1306.Test/Sang.IoT.SSD1306.Test.csproj`, `Sang.IoT.SSD1306.sln`). [[1]](diffhunk://#diff-c96e9ee080b73434f1dd270fff78a3e975b6e38fe275dec62eb018115796d83cR1-R14) [[2]](diffhunk://#diff-c6ba55f4a776594a156c8dc3e8842c610c32661a67f78afd58cc66de001e0075R8-R9)

### Documentation Improvements:
* Updated the `README.md` file with new code examples demonstrating how to use the display text and partial refresh functionalities.

### Dependency Updates:
* Updated `SkiaSharp` and `System.Device.Gpio` package versions to the latest releases (`Sang.IoT.SSD1306/Sang.IoT.SSD1306.csproj`).

### Codebase Simplification:
* Removed unnecessary `using SkiaSharp` directive from `SSD1306_128_64.cs` as it is now included in the new partial class (`Sang.IoT.SSD1306/SSD1306_128_64.cs`).

These changes collectively enhance the functionality, maintainability, and usability of the `Sang.IoT.SSD1306` library.